### PR TITLE
Enable TypeOperators Extension

### DIFF
--- a/lab-kinds.cabal
+++ b/lab-kinds.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cd557136ea41c6d680725c03e0d1ae8e5170ed4619f6d0af2f4edea4cd06937a
+-- hash: e92df001d0588b43ad251d24d12cc81523ca0ed81e78e78f1afe3ce5c5297fd0
 
 name:           lab-kinds
 version:        0.1.0.0
@@ -31,7 +31,7 @@ library
       Paths_lab_kinds
   hs-source-dirs:
       src
-  default-extensions: DataKinds
+  default-extensions: DataKinds TypeOperators
   build-depends:
       base >=4.7 && <5
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ dependencies:
 
 default-extensions:
 - DataKinds
+- TypeOperators
 
 library:
   source-dirs: src


### PR DESCRIPTION
TypeOperators allows for infix application of type operators such as `(:)`. This is needed to allow `:k Int : ’[]` in repl (the last item in the Kinds lab)